### PR TITLE
Set store_data to save introspection data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM docker.io/centos:centos7
 
 RUN yum install -y python-requests
-RUN curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - current-tripleo
+RUN curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - current
 RUN yum install -y openstack-ironic-inspector crudini 
 
 RUN crudini --set /etc/ironic-inspector/inspector.conf DEFAULT auth_strategy noauth && \ 
     crudini --set /etc/ironic-inspector/inspector.conf ironic auth_strategy noauth && \
     crudini --set /etc/ironic-inspector/inspector.conf DEFAULT debug true && \
+    crudini --set /etc/ironic-inspector/inspector.conf processing store_data database && \
     crudini --set /etc/ironic-inspector/inspector.conf pxe_filter driver noop
 
 RUN ironic-inspector-dbsync --config-file /etc/ironic-inspector/inspector.conf upgrade 
@@ -15,3 +16,4 @@ COPY ./runironic-inspector.sh /bin/runironic-inspector
 RUN chmod +x /bin/runironic-inspector
 
 ENTRYPOINT ["/bin/runironic-inspector"]
+


### PR DESCRIPTION
Sets the store_data to database to allow introspection data to be
saved and retrieved.  This uses sqlalchamy as the default store.

Note that the database support required an ironic-inspector fix -
https://review.openstack.org/#/c/636692/, which is currently not
in current-tripleo.  This temporarily changes the repo to use
current instead of current-tripleo.  This change will be reverted
once the fix is available.