### PR TITLE
Use WAL for inspector sqlite database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,13 @@ RUN yum install -y python-requests
 RUN curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - current
 RUN yum install -y openstack-ironic-inspector crudini psmisc
 
+RUN mkdir -p /var/lib/ironic-inspector && \
+    sqlite3 /var/lib/ironic-inspector/ironic-inspector.db "pragma journal_mode=wal"
+
 RUN crudini --set /etc/ironic-inspector/inspector.conf DEFAULT auth_strategy noauth && \ 
     crudini --set /etc/ironic-inspector/inspector.conf ironic auth_strategy noauth && \
     crudini --set /etc/ironic-inspector/inspector.conf DEFAULT debug true && \
+    crudini --set /etc/ironic-inspector/inspector.conf database connection sqlite:///var/lib/ironic-inspector/ironic-inspector.db && \
     crudini --set /etc/ironic-inspector/inspector.conf DEFAULT transport_url fake:// && \
     crudini --set /etc/ironic-inspector/inspector.conf processing store_data database && \
     crudini --set /etc/ironic-inspector/inspector.conf pxe_filter driver noop


### PR DESCRIPTION
Similar to what was done for for metlkube-ironic - use the write-ahead
logging to provide more concurrency between reading and writing.