### PR TITLE
Leave the power on by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN crudini --set /etc/ironic-inspector/inspector.conf DEFAULT auth_strategy noa
     crudini --set /etc/ironic-inspector/inspector.conf database connection sqlite:///var/lib/ironic-inspector/ironic-inspector.db && \
     crudini --set /etc/ironic-inspector/inspector.conf DEFAULT transport_url fake:// && \
     crudini --set /etc/ironic-inspector/inspector.conf processing store_data database && \
-    crudini --set /etc/ironic-inspector/inspector.conf pxe_filter driver noop
+    crudini --set /etc/ironic-inspector/inspector.conf pxe_filter driver noop && \
+    crudini --set /etc/ironic-inspector/inspector.conf processing power_off False
 
 RUN ironic-inspector-dbsync --config-file /etc/ironic-inspector/inspector.conf upgrade 
 


### PR DESCRIPTION
Upon completing discovery, leave the power for the
nodes on in order to support the eventual reboot skip
that will be possible once
https://review.openstack.org/#/c/635996/ has merged.