### PR TITLE
Add node not found hook and default ipmi driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ RUN crudini --set /etc/ironic-inspector/inspector.conf DEFAULT auth_strategy noa
     crudini --set /etc/ironic-inspector/inspector.conf database connection sqlite:///var/lib/ironic-inspector/ironic-inspector.db && \
     crudini --set /etc/ironic-inspector/inspector.conf DEFAULT transport_url fake:// && \
     crudini --set /etc/ironic-inspector/inspector.conf processing store_data database && \
-    crudini --set /etc/ironic-inspector/inspector.conf pxe_filter driver noop
+    crudini --set /etc/ironic-inspector/inspector.conf pxe_filter driver noop && \
+    crudini --set /etc/ironic-inspector/inspector.conf processing node_not_found_hook enroll && \
+    crudini --set /etc/ironic-inspector/inspector.conf discovery enroll_node_driver ipmi
 
 RUN ironic-inspector-dbsync --config-file /etc/ironic-inspector/inspector.conf upgrade 
 


### PR DESCRIPTION
This change allows ironic-inspector to register baremetal nodes
in ironic when they call home to ironic-inspector and are not
already known to ironic.

This also allows ironic-inspector to perform inspection on the
baremetal node.