### PR TITLE
Add logging for ironic-inspector to shared directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,11 @@ RUN crudini --set /etc/ironic-inspector/inspector.conf DEFAULT auth_strategy noa
     crudini --set /etc/ironic-inspector/inspector.conf database connection sqlite:///var/lib/ironic-inspector/ironic-inspector.db && \
     crudini --set /etc/ironic-inspector/inspector.conf DEFAULT transport_url fake:// && \
     crudini --set /etc/ironic-inspector/inspector.conf processing store_data database && \
+    crudini --set /etc/ironic-inspector/inspector.conf processing ramdisk_logs_dir /shared/log/ironic-inspector/ramdisk && \
+    crudini --set /etc/ironic-inspector/inspector.conf processing always_store_ramdisk_logs true && \
     crudini --set /etc/ironic-inspector/inspector.conf pxe_filter driver noop && \
     crudini --set /etc/ironic-inspector/inspector.conf processing node_not_found_hook enroll && \
     crudini --set /etc/ironic-inspector/inspector.conf discovery enroll_node_driver ipmi
-
 
 RUN ironic-inspector-dbsync --config-file /etc/ironic-inspector/inspector.conf upgrade 
 

--- a/runironic-inspector.sh
+++ b/runironic-inspector.sh
@@ -7,4 +7,9 @@ if ! iptables -C INPUT -i $INTERFACE -p tcp -m tcp --dport 5050 -j ACCEPT > /dev
     iptables -I INPUT -i $INTERFACE -p tcp -m tcp --dport 5050 -j ACCEPT
 fi
 
-/usr/bin/python2 /usr/bin/ironic-inspector --config-file /etc/ironic-inspector/inspector-dist.conf --config-file /etc/ironic-inspector/inspector.conf
+# Remove log files from last deployment
+rm -rf /shared/log/ironic-inspector
+
+mkdir -p /shared/log/ironic-inspector
+
+/usr/bin/python2 /usr/bin/ironic-inspector --config-file /etc/ironic-inspector/inspector-dist.conf --config-file /etc/ironic-inspector/inspector.conf --log-file /shared/log/ironic-inspector/ironic-inspector.log


### PR DESCRIPTION
Set the inspector logging to /shared. Also enable logging on the ramdisk running introspection.