### PR TITLE
Switch from "current" to "current-tripleo-rdo"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/centos:centos7
 
 RUN yum install -y python-requests
-RUN curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - current
+RUN curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - current-tripleo
 RUN yum install -y openstack-ironic-inspector crudini psmisc
 
 RUN mkdir -p /var/lib/ironic-inspector && \


### PR DESCRIPTION
Moving to use a repository that has passed the RDO
ci should protect us a bit better from regressions.