### PR TITLE
Add extra_hardware and lldp_basic to processing hooks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN crudini --set /etc/ironic-inspector/inspector.conf DEFAULT auth_strategy noa
     crudini --set /etc/ironic-inspector/inspector.conf processing always_store_ramdisk_logs true && \
     crudini --set /etc/ironic-inspector/inspector.conf pxe_filter driver noop && \
     crudini --set /etc/ironic-inspector/inspector.conf processing node_not_found_hook enroll && \
-    crudini --set /etc/ironic-inspector/inspector.conf discovery enroll_node_driver ipmi
+    crudini --set /etc/ironic-inspector/inspector.conf discovery enroll_node_driver ipmi && \
+    crudini --set /etc/ironic-inspector/inspector.conf processing processing_hooks "\$default_processing_hooks,extra_hardware,lldp_basic"
 
 RUN ironic-inspector-dbsync --config-file /etc/ironic-inspector/inspector.conf upgrade 
 


### PR DESCRIPTION
These hooks format the raw data from IPA into nicer formats:
* extra_hardware formats the python-hardware inventory from list of lists
  to nested dictionaries under the "extra" key.
* lldp_basic formats the raw LLDP data into human-readable format under
  lldp_processed on each interface.

Related to https://github.com/metal3-io/baremetal-operator/issues/179