### PR TITLE
remove extra_hardware processing hook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN crudini --set /etc/ironic-inspector/inspector.conf DEFAULT auth_strategy noa
     crudini --set /etc/ironic-inspector/inspector.conf pxe_filter driver noop && \
     crudini --set /etc/ironic-inspector/inspector.conf processing node_not_found_hook enroll && \
     crudini --set /etc/ironic-inspector/inspector.conf discovery enroll_node_driver ipmi && \
-    crudini --set /etc/ironic-inspector/inspector.conf processing processing_hooks "\$default_processing_hooks,extra_hardware,lldp_basic"
+    crudini --set /etc/ironic-inspector/inspector.conf processing processing_hooks "\$default_processing_hooks,lldp_basic"
 
 RUN ironic-inspector-dbsync --config-file /etc/ironic-inspector/inspector.conf upgrade 
 


### PR DESCRIPTION
PR #16 enabled extra_hardware processing, but there is an issue with
IPA that causes that hook to fail when there is no swift storage
backend. Disable the extra processing until that IPA bug is fixed.