### PR TITLE
Update all packages when building an image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM docker.io/centos:centos7
 RUN yum install -y python-requests && \
     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - current-tripleo && \
     yum update -y && \
-    yum install -y openstack-ironic-inspector crudini psmisc iproute iptables
+    yum install -y openstack-ironic-inspector crudini psmisc iproute iptables && \
+    yum clean all
 
 RUN mkdir -p /var/lib/ironic-inspector && \
     sqlite3 /var/lib/ironic-inspector/ironic-inspector.db "pragma journal_mode=wal"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM docker.io/centos:centos7
 
-RUN yum install -y python-requests
-RUN curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - current-tripleo
-RUN yum install -y openstack-ironic-inspector crudini psmisc iproute iptables
+RUN yum install -y python-requests && \
+    curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - current-tripleo && \
+    yum update -y && \
+    yum install -y openstack-ironic-inspector crudini psmisc iproute iptables
 
 RUN mkdir -p /var/lib/ironic-inspector && \
     sqlite3 /var/lib/ironic-inspector/ironic-inspector.db "pragma journal_mode=wal"


### PR DESCRIPTION
There may be security vulnarabilities in the pre-installed packages,
let's make sure we always have the latest versions.

Also use fewer `yum` commands to produce fewer layers.