### PR TITLE
Publish inspection collectors via mDNS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN crudini --set /etc/ironic-inspector/inspector.conf DEFAULT auth_strategy noa
     crudini --set /etc/ironic-inspector/inspector.conf discovery enroll_node_driver ipmi && \
     crudini --set /etc/ironic-inspector/inspector.conf processing processing_hooks "\$default_processing_hooks,extra_hardware,lldp_basic" && \
     # NOTE(dtantsur): keep this in sync with ironic-image/inspector.ipxe
-    # TODO(dtantsur): add ipa_inspection_collectors once we get ironic-lib 2.17.1
-    crudini --set /etc/ironic-inspector/inspector.conf mdns params 'ipa_debug:1,ipa_inspection_dhcp_all_interfaces:1,ipa_collect_lldp:1'
+    crudini --set /etc/ironic-inspector/inspector.conf mdns params \
+        'ipa_debug:1,ipa_inspection_dhcp_all_interfaces:1,ipa_collect_lldp:1,ipa_inspection_collectors:"default,extra-hardware,logs"'
 
 RUN ironic-inspector-dbsync --config-file /etc/ironic-inspector/inspector.conf upgrade 
 


### PR DESCRIPTION
This is required for PXE-less deployments to correctly detected
the list of collectors. Previously it was blocked by a bug in ironic-lib.