### PR TITLE
Set inspector power_off to false

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN crudini --set /etc/ironic-inspector/inspector.conf DEFAULT auth_strategy noa
     crudini --set /etc/ironic-inspector/inspector.conf processing store_data database && \
     crudini --set /etc/ironic-inspector/inspector.conf processing ramdisk_logs_dir /shared/log/ironic-inspector/ramdisk && \
     crudini --set /etc/ironic-inspector/inspector.conf processing always_store_ramdisk_logs true && \
+    crudini --set /etc/ironic-inspector/inspector.conf processing power_off false && \
     crudini --set /etc/ironic-inspector/inspector.conf pxe_filter driver noop && \
     crudini --set /etc/ironic-inspector/inspector.conf processing node_not_found_hook enroll && \
     crudini --set /etc/ironic-inspector/inspector.conf discovery enroll_node_driver ipmi && \


### PR DESCRIPTION
In order to enable fast_track in our usage
scenario, inspector cannot turn the power off
of the node that was just inspected.