### PR TITLE
Turn on active node introspection processing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN crudini --set /etc/ironic-inspector/inspector.conf DEFAULT auth_strategy noa
     crudini --set /etc/ironic-inspector/inspector.conf processing node_not_found_hook enroll && \
     crudini --set /etc/ironic-inspector/inspector.conf discovery enroll_node_driver ipmi && \
     crudini --set /etc/ironic-inspector/inspector.conf processing processing_hooks "\$default_processing_hooks,extra_hardware,lldp_basic" && \
+    crudini --set /etc/ironic-inspector/inspector.conf processing permit_active_introspection true && \
     # NOTE(dtantsur): keep this in sync with ironic-image/inspector.ipxe
     crudini --set /etc/ironic-inspector/inspector.conf mdns params \
         'ipa_debug:1,ipa_inspection_dhcp_all_interfaces:1,ipa_collect_lldp:1,ipa_inspection_collectors:"default,extra-hardware,logs"'


### PR DESCRIPTION
Adds configuration to enable a feature of ironic-inspector
9.1.0 which allows for active nodes to be processed when
posted to inspection which will allow nodes data to be updated.