### PR TITLE
Changes to use Ironic Stein

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/centos:centos7
 
 RUN yum install -y python-requests && \
-    curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - current-tripleo && \
+    curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - -b stein current-tripleo && \
     yum update -y && \
     yum install -y openstack-ironic-inspector crudini psmisc iproute iptables && \
     yum clean all
@@ -15,7 +15,6 @@ RUN crudini --set /etc/ironic-inspector/inspector.conf DEFAULT auth_strategy noa
     crudini --set /etc/ironic-inspector/inspector.conf DEFAULT debug true && \
     crudini --set /etc/ironic-inspector/inspector.conf database connection sqlite:///var/lib/ironic-inspector/ironic-inspector.db && \
     crudini --set /etc/ironic-inspector/inspector.conf DEFAULT transport_url fake:// && \
-    crudini --set /etc/ironic-inspector/inspector.conf DEFAULT enable_mdns True && \
     crudini --set /etc/ironic-inspector/inspector.conf processing store_data database && \
     crudini --set /etc/ironic-inspector/inspector.conf processing ramdisk_logs_dir /shared/log/ironic-inspector/ramdisk && \
     crudini --set /etc/ironic-inspector/inspector.conf processing always_store_ramdisk_logs true && \
@@ -23,11 +22,7 @@ RUN crudini --set /etc/ironic-inspector/inspector.conf DEFAULT auth_strategy noa
     crudini --set /etc/ironic-inspector/inspector.conf pxe_filter driver noop && \
     crudini --set /etc/ironic-inspector/inspector.conf processing node_not_found_hook enroll && \
     crudini --set /etc/ironic-inspector/inspector.conf discovery enroll_node_driver ipmi && \
-    crudini --set /etc/ironic-inspector/inspector.conf processing processing_hooks "\$default_processing_hooks,extra_hardware,lldp_basic" && \
-    crudini --set /etc/ironic-inspector/inspector.conf processing permit_active_introspection true && \
-    # NOTE(dtantsur): keep this in sync with ironic-image/inspector.ipxe
-    crudini --set /etc/ironic-inspector/inspector.conf mdns params \
-        'ipa_debug:1,ipa_inspection_dhcp_all_interfaces:1,ipa_collect_lldp:1,ipa_inspection_collectors:"default,extra-hardware,logs"'
+    crudini --set /etc/ironic-inspector/inspector.conf processing processing_hooks "\$default_processing_hooks,extra_hardware,lldp_basic"
 
 RUN ironic-inspector-dbsync --config-file /etc/ironic-inspector/inspector.conf upgrade 
 


### PR DESCRIPTION
This patch contains changes needed to be able to use Ironic Stein.

It has dependencies from other patches in other related repos
and they should all be merged at the same time, following the order below,
to guarantee a correct behavior.

Full patch set:
https://github.com/openshift-metal3/dev-scripts/pull/680
https://github.com/metal3-io/ironic-image/pull/79
https://github.com/metal3-io/ironic-inspector-image/pull/30
https://github.com/metal3-io/ironic-ipa-downloader/pull/3
