### PR TITLE
Wait for PROVISIONING_INTERFACE to be up

### DIFF
--- a/runironic-inspector.sh
+++ b/runironic-inspector.sh
@@ -5,6 +5,12 @@ PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE:-"provisioning"}
 CONFIG=/etc/ironic-inspector/inspector.conf
 PROVISIONING_IP=$(ip -4 address show dev "$PROVISIONING_INTERFACE" | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -n 1)
 
+until [ ! -z "${PROVISIONING_IP}" ]; do
+  echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
+  sleep 1
+  PROVISIONING_IP=$(ip -4 address show dev "$PROVISIONING_INTERFACE" | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -n 1)
+done
+
 # Allow access to Ironic inspector API
 if ! iptables -C INPUT -i "$PROVISIONING_INTERFACE" -p tcp -m tcp --dport 5050 -j ACCEPT > /dev/null 2>&1; then
     iptables -I INPUT -i "$PROVISIONING_INTERFACE" -p tcp -m tcp --dport 5050 -j ACCEPT


### PR DESCRIPTION
We've seen some issues where the static-ip-refresh doesn't happen quickly
enough, and/or static-ip-set from initContainers expires before we start
the ironic containers.

To ensure we don't fail in that case, wait for the provisioning IP to be
assigned, then the exact order of container start is not important, and
we'll wait until static-ip-refresh has configured the nic.