### PR TITLE
Re-adding Train features

### DIFF
--- a/inspector.conf
+++ b/inspector.conf
@@ -1,6 +1,7 @@
 [DEFAULT]
 auth_strategy = noauth
 debug = true
+enable_mdns = true
 transport_url = fake://
 use_stderr = true
 
@@ -13,9 +14,14 @@ enroll_node_driver = ipmi
 [ironic]
 auth_type = none
 
+[mdns]
+# NOTE(dtantsur): keep this in sync with ironic-image/inspector.ipxe
+params = 'ipa_debug:1,ipa_inspection_dhcp_all_interfaces:1,ipa_collect_lldp:1,ipa_inspection_collectors:"default,extra-hardware,logs"'
+
 [processing]
 always_store_ramdisk_logs = true
 node_not_found_hook = enroll
+permit_active_introspection = true
 power_off = false
 processing_hooks = $default_processing_hooks,extra_hardware,lldp_basic
 ramdisk_logs_dir = /shared/log/ironic-inspector/ramdisk


### PR DESCRIPTION
This patch adds back the features that were removed because we
were on Stain branch:
- continuous introspection
- ironic-prometheus-exporter
- mdns support

Please merge this and https://github.com/metal3-io/ironic-image/pull/101 at the same time!