### PR TITLE
Remove iptables filters from ironic-inspector containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/centos:centos7
 RUN yum install -y python-requests && \
     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - -b train current-tripleo && \
     yum update -y && \
-    yum install -y openstack-ironic-inspector crudini psmisc iproute iptables && \
+    yum install -y openstack-ironic-inspector crudini psmisc iproute && \
     yum clean all && rm -rf /var/cache/yum/*
 
 RUN mkdir -p /var/lib/ironic-inspector && \

--- a/runironic-inspector.sh
+++ b/runironic-inspector.sh
@@ -6,19 +6,6 @@ CONFIG=/etc/ironic-inspector/inspector.conf
 
 wait_for_interface_or_ip
 
-# Allow access to Ironic inspector API
-if ! iptables -C INPUT -i "$PROVISIONING_INTERFACE" -p tcp -m tcp --dport 5050 -j ACCEPT > /dev/null 2>&1; then
-    iptables -I INPUT -i "$PROVISIONING_INTERFACE" -p tcp -m tcp --dport 5050 -j ACCEPT
-fi
-
-# Allow access to mDNS
-if ! iptables -C INPUT -i $PROVISIONING_INTERFACE -p udp --dport 5353 -j ACCEPT > /dev/null 2>&1; then
-    iptables -I INPUT -i $PROVISIONING_INTERFACE -p udp --dport 5353 -j ACCEPT
-fi
-if ! iptables -C OUTPUT -p udp --dport 5353 -j ACCEPT > /dev/null 2>&1; then
-    iptables -I OUTPUT -p udp --dport 5353 -j ACCEPT
-fi
-
 # Remove log files from last deployment
 rm -rf /shared/log/ironic-inspector
 


### PR DESCRIPTION
We don't appear to need these, infact they output
errors on container startup...