### PR TITLE
Disabling mdns for ipv6 testing

### DIFF
--- a/inspector.conf
+++ b/inspector.conf
@@ -1,7 +1,6 @@
 [DEFAULT]
 auth_strategy = noauth
 debug = true
-enable_mdns = true
 transport_url = fake://
 use_stderr = true
 
@@ -13,10 +12,6 @@ enroll_node_driver = ipmi
 
 [ironic]
 auth_type = none
-
-[mdns]
-# NOTE(dtantsur): keep this in sync with ironic-image/inspector.ipxe
-params = 'ipa_debug:1,ipa_inspection_dhcp_all_interfaces:1,ipa_collect_lldp:1,ipa_inspection_collectors:"default,extra-hardware,logs"'
 
 [processing]
 always_store_ramdisk_logs = true


### PR DESCRIPTION
The mdns feature is not compatible with ipv6 yet.