### PR TITLE
Removing forgotten mdns conf param

### DIFF
--- a/runironic-inspector.sh
+++ b/runironic-inspector.sh
@@ -33,7 +33,6 @@ cp $CONFIG $CONFIG.orig
 
 crudini --set $CONFIG ironic endpoint_override http://$PROVISIONING_IP:6385
 crudini --set $CONFIG service_catalog endpoint_override http://$PROVISIONING_IP:5050
-crudini --set $CONFIG mdns interfaces $PROVISIONING_IP
 
 exec /usr/bin/ironic-inspector --config-file /etc/ironic-inspector/inspector-dist.conf \
 	--config-file /etc/ironic-inspector/inspector.conf \


### PR DESCRIPTION
Removing a forgotten mdns configuration parameter that
might interfere if mdns is disabled.