### PR TITLE
Sync ironic-common.sh with ironic-image

### DIFF
--- a/ironic-common.sh
+++ b/ironic-common.sh
@@ -5,6 +5,7 @@ function wait_for_interface_or_ip() {
   # If $PROVISIONING_IP is specified, then we wait for that to become available on an interface, otherwise we look at $PROVISIONING_INTERFACE for an IP
   if [ ! -z "${PROVISIONING_IP}" ];
   then
+    IRONIC_IP=""
     until [ ! -z "${IRONIC_IP}" ]; do
       echo "Waiting for ${PROVISIONING_IP} to be configured on an interface"
       IRONIC_IP=$(ip -br addr show | grep "${PROVISIONING_IP}" | grep -Po "[^\s]+/[0-9]+" | sed -e 's%/.*%%' | head -n 1)
@@ -16,14 +17,16 @@ function wait_for_interface_or_ip() {
       IRONIC_IP=$(ip -br addr show dev $PROVISIONING_INTERFACE | grep -Po "[^\s]+/[0-9]+" | grep -e "^fd" -e "\." | sed -e 's%/.*%%' | head -n 1)
       sleep 1
     done
+  fi
 
-    # If the IP contains a colon, then it's an IPv6 address, and the HTTP
-    # host needs surrounding with brackets
-    if [[ "$IRONIC_IP" =~ .*:.* ]]
-    then
-      IRONIC_URL_HOST="[$IRONIC_IP]"
-    else
-      IRONIC_URL_HOST=$IRONIC_IP
-    fi
+  # If the IP contains a colon, then it's an IPv6 address, and the HTTP
+  # host needs surrounding with brackets
+  if [[ "$IRONIC_IP" =~ .*:.* ]]
+  then
+    IPV=6
+    IRONIC_URL_HOST="[$IRONIC_IP]"
+  else
+    IPV=4
+    IRONIC_URL_HOST=$IRONIC_IP
   fi
 }


### PR DESCRIPTION
The inspector image has a typo in ironic-common.sh that's preventing the
endpoint for Ironic to be set correctly when using IPv6.  This matches
ironic-common.sh with the exact one from the ironic-image which already
got the fix for this.