### PR TITLE
Reduce distro specific packages when creating ironic-inspector image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,23 @@
 FROM docker.io/centos:centos8
 
-RUN dnf install -y python3 python3-requests && \
+RUN dnf install -y gcc python3-devel python3 python3-requests git && \
     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python3 - -b master current && \
     dnf update -y && \
-    dnf install -y openstack-ironic-inspector crudini psmisc iproute sqlite && \
+    dnf install -y crudini psmisc iproute sqlite && \
     mkdir -p /var/lib/ironic-inspector && \
     sqlite3 /var/lib/ironic-inspector/ironic-inspector.db "pragma journal_mode=wal" && \
     dnf remove -y sqlite && \
     dnf clean all && \
     rm -rf /var/cache/{yum,dnf}/*
 
+RUN pip3 install git+https://opendev.org/openstack/ironic-inspector.git@master
+
 COPY ./inspector.conf /tmp/inspector.conf
+RUN mkdir /etc/ironic-inspector/
+RUN touch /etc/ironic-inspector/inspector.conf
+
+COPY ./inspector-dist.conf /etc/ironic-inspector/inspector-dist.conf
+
 RUN crudini --merge /etc/ironic-inspector/inspector.conf < /tmp/inspector.conf && \
     rm /tmp/inspector.conf
 
@@ -20,8 +27,8 @@ COPY ./runironic-inspector.sh /bin/runironic-inspector
 COPY ./runhealthcheck.sh /bin/runhealthcheck
 COPY ./ironic-common.sh /bin/ironic-common.sh
 
-HEALTHCHECK CMD /bin/runhealthcheck
+# HEALTHCHECK CMD /bin/runhealthcheck
 RUN chmod +x /bin/runironic-inspector
-
+RUN ln -s /usr/local/bin/ironic-inspector /bin/ironic-inspector
 ENTRYPOINT ["/bin/runironic-inspector"]
 

--- a/inspector-dist.conf
+++ b/inspector-dist.conf
@@ -1,0 +1,4 @@
+[DEFAULT]
+log_dir = /var/log/ironic-inspector
+state_path = /var/lib/ironic-inspector
+use_stderr = True

--- a/runironic-inspector.sh
+++ b/runironic-inspector.sh
@@ -16,6 +16,6 @@ cp $CONFIG $CONFIG.orig
 crudini --set $CONFIG ironic endpoint_override http://$IRONIC_URL_HOST:6385
 crudini --set $CONFIG service_catalog endpoint_override http://$IRONIC_URL_HOST:5050
 
-exec /usr/bin/ironic-inspector --config-file /etc/ironic-inspector/inspector-dist.conf \
+exec $(which ironic-inspector) --config-file /etc/ironic-inspector/inspector-dist.conf \
 	--config-file /etc/ironic-inspector/inspector.conf \
 	--log-file /shared/log/ironic-inspector/ironic-inspector.log


### PR DESCRIPTION
Currently, ironic-inspector image building process uses centos-8 as a base image.

The purpose of this commit is reducing the dependency on a any specific distribution.
It installs ironic-inspector from the repo using pip3.