### PR TITLE
Allow any IPv6 address to be configured for provisioning instead of link local scope

### DIFF
--- a/ironic-common.sh
+++ b/ironic-common.sh
@@ -1,20 +1,20 @@
-PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE:-"provisioning"}
+export PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE:-"provisioning"}
 
 # Wait for the interface or IP to be up, sets $IRONIC_IP
 function wait_for_interface_or_ip() {
   # If $PROVISIONING_IP is specified, then we wait for that to become available on an interface, otherwise we look at $PROVISIONING_INTERFACE for an IP
   if [ ! -z "${PROVISIONING_IP}" ];
   then
-    IRONIC_IP=""
+    export IRONIC_IP=""
     until [ ! -z "${IRONIC_IP}" ]; do
       echo "Waiting for ${PROVISIONING_IP} to be configured on an interface"
-      IRONIC_IP=$(ip -br addr show | grep "${PROVISIONING_IP}" | grep -Po "[^\s]+/[0-9]+" | sed -e 's%/.*%%' | head -n 1)
+      export IRONIC_IP=$(ip -br addr show | grep "${PROVISIONING_IP}" | grep -Po "[^\s]+/[0-9]+" | sed -e 's%/.*%%' | head -n 1)
       sleep 1
     done
   else
     until [ ! -z "${IRONIC_IP}" ]; do
       echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
-      IRONIC_IP=$(ip -br addr show dev $PROVISIONING_INTERFACE | grep -Po "[^\s]+/[0-9]+" | grep -e "^fd" -e "\." | sed -e 's%/.*%%' | head -n 1)
+      export IRONIC_IP=$(ip -br add show scope global up dev "${PROVISIONING_INTERFACE}" | awk '{print $3}' | sed -e 's%/.*%%' | head -n 1)
       sleep 1
     done
   fi
@@ -23,10 +23,10 @@ function wait_for_interface_or_ip() {
   # host needs surrounding with brackets
   if [[ "$IRONIC_IP" =~ .*:.* ]]
   then
-    IPV=6
-    IRONIC_URL_HOST="[$IRONIC_IP]"
+    export IPV=6
+    export IRONIC_URL_HOST="[$IRONIC_IP]"
   else
-    IPV=4
-    IRONIC_URL_HOST=$IRONIC_IP
+    export IPV=4
+    export IRONIC_URL_HOST=$IRONIC_IP
   fi
 }


### PR DESCRIPTION
This PR fixes an issue when using routable IPv6 addresses for the provisioning network. The previous grep command only matched local unicast addresses, this new grep will match any IPv6 address, but the link local scope.

The ironic-inspector container keeps waiting for "PROVISIONING_INTERFACE" to be configured otherwise.

Fixes https://github.com/metal3-io/ironic-inspector-image/issues/56