### PR TITLE
Simplify HTTP basic auth configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/centos:centos8
 RUN dnf install -y python3 python3-requests && \
     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python3 - -b master current-tripleo && \
     dnf update -y && \
-    dnf install -y openstack-ironic-inspector crudini psmisc iproute sqlite httpd-tools && \
+    dnf install -y openstack-ironic-inspector crudini psmisc iproute sqlite && \
     mkdir -p /var/lib/ironic-inspector && \
     sqlite3 /var/lib/ironic-inspector/ironic-inspector.db "pragma journal_mode=wal" && \
     dnf remove -y sqlite && \


### PR DESCRIPTION
Make HTTP basic auth configuration simpler, more flexible, and a better fit and more secure when used with standard k8s deployment techniques.

* Allow basic_auth to be configured independently on client and server
  interfaces, based on the presence of the required configuration data,
  rather than using a single global USE_HTTP_BASIC environment variable.
* Expect the server credentials to be passed in the form of an
  HTTP_BASIC_HTPASSWD environment variable containing both the username
  and the *hash* of the password, in the htpasswd format. This is more
  secure, as it allows the container not to hold a copy of the password
  when it doesn't need it purely for authenticating connections.
* Expect client credentials to be passed in the form of a file named
  /basic_auth/ironic/auth-config, formatted as an ini config file
  setting the appropriate options (for basic auth, this is
  auth_strategy=http_basic, and the username and password options; however
  this mechanism should work unchanged for other auth strategies). This is
  more secure because in k8s the password is never passed as an
  environment variable nor written to disk, but remains in a tmpfs
  filesystem.