### PR TITLE
Add TLS support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,7 @@ RUN dnf install -y python3 python3-requests && \
     dnf clean all && \
     rm -rf /var/cache/{yum,dnf}/*
 
-COPY ./inspector.conf /tmp/inspector.conf
-RUN crudini --merge /etc/ironic-inspector/inspector.conf < /tmp/inspector.conf && \
-    rm /tmp/inspector.conf
-
-RUN ironic-inspector-dbsync --config-file /etc/ironic-inspector/inspector.conf upgrade 
-
+COPY ./inspector.conf.j2 /etc/ironic-inspector/ironic-inspector.conf.j2
 COPY ./runironic-inspector.sh /bin/runironic-inspector
 COPY ./runhealthcheck.sh /bin/runhealthcheck
 COPY ./ironic-common.sh /bin/ironic-common.sh

--- a/inspector.conf.j2
+++ b/inspector.conf.j2
@@ -4,6 +4,10 @@ debug = true
 transport_url = fake://
 use_stderr = true
 listen_address = ::
+host = {{ env.IRONIC_IP }}
+{% if env.IRONIC_INSPECTOR_TLS_SETUP == "true" %}
+use_ssl = true
+{% endif %}
 
 [database]
 connection = sqlite:///var/lib/ironic-inspector/ironic-inspector.db
@@ -13,6 +17,10 @@ enroll_node_driver = ipmi
 
 [ironic]
 auth_type = none
+endpoint_override = {{ env.IRONIC_BASE_URL }}
+{% if env.IRONIC_TLS_SETUP == "true" %}
+cafile = {{ env.IRONIC_CACERT_FILE }}
+{% endif %}
 
 [processing]
 add_ports = all
@@ -30,3 +38,10 @@ driver = noop
 
 [service_catalog]
 auth_type = none
+endpoint_override = {{ env.IRONIC_INSPECTOR_BASE_URL }}
+
+{% if env.IRONIC_INSPECTOR_TLS_SETUP == "true" %}
+[ssl]
+cert_file = {{ env.IRONIC_INSPECTOR_CERT_FILE }}
+key_file = {{ env.IRONIC_INSPECTOR_KEY_FILE }}
+{% endif %}

--- a/ironic-common.sh
+++ b/ironic-common.sh
@@ -1,32 +1,41 @@
 export PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE:-"provisioning"}
 
 # Wait for the interface or IP to be up, sets $IRONIC_IP
-function wait_for_interface_or_ip() {
+function get_ironic_ip() {
   # If $PROVISIONING_IP is specified, then we wait for that to become available on an interface, otherwise we look at $PROVISIONING_INTERFACE for an IP
   if [ ! -z "${PROVISIONING_IP}" ];
   then
-    export IRONIC_IP=""
-    until [ ! -z "${IRONIC_IP}" ]; do
-      echo "Waiting for ${PROVISIONING_IP} to be configured on an interface"
-      export IRONIC_IP=$(ip -br addr show | grep "${PROVISIONING_IP}" | grep -Po "[^\s]+/[0-9]+" | sed -e 's%/.*%%' | head -n 1)
-      sleep 1
-    done
+    echo "Waiting for ${PROVISIONING_IP} to be configured on an interface"
+    export IRONIC_IP=$(ip -br addr show | grep "${PROVISIONING_IP}" | grep -Po "[^\s]+/[0-9]+" | sed -e 's%/.*%%' | head -n 1)
+    # When an interface has multiple IP addresses, having IRONIC_IP set at this point means that the desired provisioning ip is set on the
+    # interface. However, the address returned might not be the desired one (no control over the order), so setting it back to the
+    # desired IP
+    if [ ! -z "${IRONIC_IP}" ]; then
+      export IRONIC_IP="$(echo ${PROVISIONING_IP} | sed -e 's%/.*%%' )"
+    fi
   else
-    until [ ! -z "${IRONIC_IP}" ]; do
-      echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
-      export IRONIC_IP=$(ip -br add show scope global up dev "${PROVISIONING_INTERFACE}" | awk '{print $3}' | sed -e 's%/.*%%' | head -n 1)
-      sleep 1
-    done
+    echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
+    export IRONIC_IP=$(ip -br add show scope global up dev "${PROVISIONING_INTERFACE}" | awk '{print $3}' | sed -e 's%/.*%%' | head -n 1)
   fi
 
-  # If the IP contains a colon, then it's an IPv6 address, and the HTTP
-  # host needs surrounding with brackets
-  if [[ "$IRONIC_IP" =~ .*:.* ]]
-  then
-    export IPV=6
-    export IRONIC_URL_HOST="[$IRONIC_IP]"
-  else
-    export IPV=4
-    export IRONIC_URL_HOST=$IRONIC_IP
+  if [ ! -z "${IRONIC_IP}" ]; then
+    # If the IP contains a colon, then it's an IPv6 address, and the HTTP
+    # host needs surrounding with brackets
+    if [[ "$IRONIC_IP" =~ .*:.* ]]
+    then
+      export IPV=6
+      export IRONIC_URL_HOST="[$IRONIC_IP]"
+    else
+      export IPV=4
+      export IRONIC_URL_HOST=$IRONIC_IP
+    fi
   fi
+}
+
+function wait_for_interface_or_ip() {
+  export IRONIC_IP=""
+  until [ ! -z "${IRONIC_IP}" ]; do
+    get_ironic_ip
+    sleep 1
+  done
 }

--- a/runhealthcheck.sh
+++ b/runhealthcheck.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 set -ex
 
+IRONIC_INSPECTOR_CACERT_FILE=/certs/ca/ironic-inspector/tls.crt
+IRONIC_INSPECTOR_CERT_FILE=/certs/ironic-inspector/tls.crt
 
-curl -s http://127.0.0.1:5050
+. /bin/ironic-common.sh
+get_ironic_ip
+#If the IP is not set, we are not running yet
+[ -z $IRONIC_IP ] && exit 1
+
+if [ ! -f "$IRONIC_INSPECTOR_CERT_FILE" ] && [ ! -f "$IRONIC_INSPECTOR_CACERT_FILE" ]; then
+    curl -s http://${IRONIC_URL_HOST}:5050
+else
+    CACERT_FILE="${IRONIC_INSPECTOR_CACERT_FILE}"
+    if [ ! -f "${IRONIC_INSPECTOR_CACERT_FILE}" ]; then
+        CACERT_FILE="${IRONIC_INSPECTOR_CERT_FILE}"
+    fi
+    curl --cacert "$CACERT_FILE" -s "https://${IRONIC_URL_HOST}:5050"
+fi

--- a/runironic-inspector.sh
+++ b/runironic-inspector.sh
@@ -1,16 +1,57 @@
 #!/usr/bin/bash
 
-CONFIG=/etc/ironic-inspector/inspector.conf
+CONFIG=/etc/ironic-inspector/ironic-inspector.conf
+
+export IRONIC_CERT_FILE=/certs/ironic/tls.crt
+export IRONIC_CACERT_FILE=/certs/ca/ironic/tls.crt
+export IRONIC_INSPECTOR_CACERT_FILE=/certs/ca/ironic-inspector/tls.crt
+export IRONIC_INSPECTOR_CERT_FILE=/certs/ironic-inspector/tls.crt
+export IRONIC_INSPECTOR_KEY_FILE=/certs/ironic-inspector/tls.key
+
+if [ -f "$IRONIC_INSPECTOR_CERT_FILE" ] && [ ! -f "$IRONIC_INSPECTOR_KEY_FILE" ] ; then
+    echo "Missing TLS Certificate key file /certs/ironic-inspector/tls.key"
+    exit 1
+fi
+if [ ! -f "$IRONIC_INSPECTOR_CERT_FILE" ] && [ -f "$IRONIC_INSPECTOR_KEY_FILE" ] ; then
+    echo "Missing TLS Certificate file /certs/ironic-inspector/tls.crt"
+    exit 1
+fi
 
 . /bin/ironic-common.sh
 
 wait_for_interface_or_ip
 
+if [ -f "$IRONIC_INSPECTOR_CERT_FILE" ]; then
+    export IRONIC_INSPECTOR_TLS_SETUP="true"
+    export IRONIC_INSPECTOR_BASE_URL="https://${IRONIC_URL_HOST}:5050"
+    if [ ! -f "${IRONIC_INSPECTOR_CACERT_FILE}"]; then
+        cp "${IRONIC_INSPECTOR_CERT_FILE}" "${IRONIC_INSPECTOR_CACERT_FILE}"
+    fi
+else
+    export IRONIC_INSPECTOR_TLS_SETUP="false"
+    export IRONIC_INSPECTOR_BASE_URL="http://${IRONIC_URL_HOST}:5050"
+fi
+
+if [ -f "$IRONIC_CERT_FILE" ] || [ -f "$IRONIC_CACERT_FILE" ]; then
+    export IRONIC_TLS_SETUP="true"
+    export IRONIC_BASE_URL="https://${IRONIC_URL_HOST}:6385"
+    if [ ! -f "${IRONIC_CACERT_FILE}"]; then
+        cp "${IRONIC_CERT_FILE}" "${IRONIC_CACERT_FILE}"
+    fi
+else
+    export IRONIC_TLS_SETUP="false"
+    export IRONIC_BASE_URL="http://${IRONIC_URL_HOST}:6385"
+fi
+
+
 cp $CONFIG $CONFIG.orig
 
-crudini --set $CONFIG ironic endpoint_override http://$IRONIC_URL_HOST:6385
-crudini --set $CONFIG service_catalog endpoint_override http://$IRONIC_URL_HOST:5050
+function build_j2_config() {
+python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < $CONFIG.j2
+}
 
+# Merge with the original configuration file from the package.
+build_j2_config | crudini --merge /etc/ironic-inspector/ironic-inspector.conf
 
 # Configure HTTP basic auth for API server
 HTPASSWD_FILE=/etc/ironic-inspector/htpasswd
@@ -26,5 +67,7 @@ auth_config_file="/auth/ironic/auth-config"
 if [ -f ${auth_config_file} ]; then
     CONFIG_OPTIONS+=" --config-file ${auth_config_file}"
 fi
+
+ironic-inspector-dbsync --config-file /etc/ironic-inspector/ironic-inspector.conf upgrade
 
 exec /usr/bin/ironic-inspector $CONFIG_OPTIONS


### PR DESCRIPTION
This commit allows the user to start Inspector using TLS on all
endpoints, by setting the following environment variables:

- CACERT_FILE: path to the CA cert
- CERT_FILE: path to the cert
- KEY_FILE: path to the key