### PR TITLE
Make searching for Provisioning IP robust

### DIFF
--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -5,13 +5,10 @@ function get_ironic_ip() {
   # If $PROVISIONING_IP is specified, then we wait for that to become available on an interface, otherwise we look at $PROVISIONING_INTERFACE for an IP
   if [ ! -z "${PROVISIONING_IP}" ];
   then
-    echo "Waiting for ${PROVISIONING_IP} to be configured on an interface"
-    export IRONIC_IP=$(ip -br addr show | grep "${PROVISIONING_IP}" | grep -Po "[^\s]+/[0-9]+" | sed -e 's%/.*%%' | head -n 1)
-    # When an interface has multiple IP addresses, having IRONIC_IP set at this point means that the desired provisioning ip is set on the
-    # interface. However, the address returned might not be the desired one (no control over the order), so setting it back to the
-    # desired IP
-    if [ ! -z "${IRONIC_IP}" ]; then
-      export IRONIC_IP="$(echo ${PROVISIONING_IP} | sed -e 's%/.*%%' )"
+    local prov_ip=$(printf %s "${PROVISIONING_IP}" | sed -e 's%/.*%%')
+    echo "Waiting for ${prov_ip} to be configured on an interface"
+    if ip -br addr show | grep -q -F " ${prov_ip}/"; then
+      export IRONIC_IP="${prov_ip}"
     fi
   else
     echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"


### PR DESCRIPTION
Using grep with a user-supplied query that is likely to contain `.`
characters is not the most robust method of searching for a string in
some output. For example, passing `PROVISIONING_IP=192.168.1.2` would also
match e.g. 192.168.122.1. Avoid this by searching for a fixed string,
including the characters before and after the IP address.

The best way to do this would be using the json output from the ip
command:

    [ -n $(ip -j addr show | jq -r ".[] | .addr_info[] | .local | select(. == ${IRONIC_IP})") ]

and something similar to get the IP address when only the provisioning
interface is specfied:

    ip -j add show scope global up dev ${PROVISIONING_INTERFACE} | jq -r .[0].addr_info[0].local

but continuing to do it with grep avoids having to install the jq tool.