### PR TITLE
Add runlogwatch.sh entry point to dump ramdisk inspection logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY ./inspector.conf.j2 /etc/ironic-inspector/ironic-inspector.conf.j2
 COPY ./runironic-inspector.sh /bin/runironic-inspector
 COPY ./runhealthcheck.sh /bin/runhealthcheck
 COPY ./ironic-common.sh /bin/ironic-common.sh
+COPY ./runlogwatch.sh /bin/runlogwatch.sh
 
 HEALTHCHECK CMD /bin/runhealthcheck
 RUN chmod +x /bin/runironic-inspector

--- a/runlogwatch.sh
+++ b/runlogwatch.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/bash
+
+# Ramdisk logs path
+LOG_DIR="/shared/log/ironic-inspector/ramdisk"
+
+while :
+do
+    until  ls "${LOG_DIR}"/*.tar.gz 1> /dev/null 2>&1
+    do
+        sleep 5
+    done
+
+    for fn in "${LOG_DIR}"/*.tar.gz
+    do
+        echo "************ Contents of $fn ramdisk log file bundle **************"
+        tar -xOzvvf $fn | sed -e "s/^/$(basename $fn): /"
+        rm -f $fn
+    done
+done


### PR DESCRIPTION
This is ironic-inspector-image change in series of PRs implementing this design proposal: https://github.com/metal3-io/metal3-docs/blob/master/design/ironic-debuggability-improvement.md