### PR TITLE
Disable node discovery by default

### DIFF
--- a/inspector.conf.j2
+++ b/inspector.conf.j2
@@ -12,8 +12,10 @@ use_ssl = true
 [database]
 connection = sqlite:///var/lib/ironic-inspector/ironic-inspector.db
 
+{% if env.IRONIC_INSPECTOR_ENABLE_DISCOVERY == "true" %}
 [discovery]
 enroll_node_driver = ipmi
+{% endif %}
 
 [ironic]
 auth_type = none
@@ -26,7 +28,9 @@ cafile = {{ env.IRONIC_CACERT_FILE }}
 add_ports = all
 always_store_ramdisk_logs = true
 keep_ports = present
+{% if env.IRONIC_INSPECTOR_ENABLE_DISCOVERY == "true" %}
 node_not_found_hook = enroll
+{% endif %}
 permit_active_introspection = true
 power_off = false
 processing_hooks = $default_processing_hooks,extra_hardware,lldp_basic

--- a/runironic-inspector.sh
+++ b/runironic-inspector.sh
@@ -2,6 +2,8 @@
 
 CONFIG=/etc/ironic-inspector/ironic-inspector.conf
 
+export IRONIC_INSPECTOR_ENABLE_DISCOVERY=${IRONIC_INSPECTOR_ENABLE_DISCOVERY:-false}
+
 export IRONIC_CERT_FILE=/certs/ironic/tls.crt
 export IRONIC_CACERT_FILE=/certs/ca/ironic/tls.crt
 export IRONIC_INSPECTOR_CACERT_FILE=/certs/ca/ironic-inspector/tls.crt


### PR DESCRIPTION
Discovery of new nodes requires explicit support from BMO, which
does not seem to exist, nor is on the roadmap. Having discovery
enabled may cause hard to debug situations when an accidentally
booted IPA results in a new node added.

An option is left to enable discovery for testing purposes or
for future implementation on the BMO side.