### PR TITLE
Apache reverse proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ RUN prepare-image.sh && \
 COPY ironic-inspector.conf.j2 /etc/ironic-inspector/
 COPY scripts/ /bin/
 
+COPY ./inspector-apache.conf.j2 /etc/httpd/conf.d/ironic-inspector.conf.j2
 HEALTHCHECK CMD /bin/runhealthcheck
+RUN rm /etc/httpd/conf.d/ssl.conf -f
+RUN chmod +x /bin/runironic-inspector 
 
 ENTRYPOINT ["/bin/runironic-inspector"]

--- a/inspector-apache.conf.j2
+++ b/inspector-apache.conf.j2
@@ -1,0 +1,43 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+Listen 5050
+<VirtualHost *:5050>
+    ProxyPass "/"  "http://127.0.0.1:5049/"
+    ProxyPassReverse "/"  "http://127.0.0.1:5049/"
+
+    SetEnv APACHE_RUN_USER ironic-inspector
+    SetEnv APACHE_RUN_GROUP ironic-inspector
+
+    ErrorLog /dev/stdout
+    LogLevel debug
+    CustomLog /dev/stdout combined
+
+    ServerName 172.22.0.2
+
+    SSLEngine On
+    SSLCertificateFile {{ env.IRONIC_INSPECTOR_CERT_FILE }} 
+    SSLCertificateKeyFile {{ env.IRONIC_INSPECTOR_KEY_FILE }}
+
+
+     <Location /v1/introspection/ >
+         {% if "HTTP_BASIC_HTPASSWD" in env and env.HTTP_BASIC_HTPASSWD | length %}
+            AuthType Basic
+            AuthName "Restricted area"
+            AuthUserFile "/etc/ironic-inspector/htpasswd"
+            Require valid-user
+         {% endif %}
+     </Location>
+
+
+</VirtualHost>

--- a/ironic-inspector.conf.j2
+++ b/ironic-inspector.conf.j2
@@ -3,9 +3,14 @@ auth_strategy = noauth
 debug = true
 transport_url = fake://
 use_stderr = true
+{% if env.INSPECTOR_REVERSE_PROXY_SETUP == "true" %}
+listen_port = 5049
+listen_address = 127.0.0.1
+{% else %}
 listen_address = ::
+{% endif %}
 host = {{ env.IRONIC_IP }}
-{% if env.IRONIC_INSPECTOR_TLS_SETUP == "true" %}
+{% if env.IRONIC_INSPECTOR_TLS_SETUP == "true" and env.INSPECTOR_REVERSE_PROXY_SETUP == "false" %}
 use_ssl = true
 {% endif %}
 
@@ -45,7 +50,7 @@ driver = noop
 auth_type = none
 endpoint_override = {{ env.IRONIC_INSPECTOR_BASE_URL }}
 
-{% if env.IRONIC_INSPECTOR_TLS_SETUP == "true" %}
+{% if env.IRONIC_INSPECTOR_TLS_SETUP == "true" and env.INSPECTOR_REVERSE_PROXY_SETUP == "false" %}
 [ssl]
 cert_file = {{ env.IRONIC_INSPECTOR_CERT_FILE }}
 key_file = {{ env.IRONIC_INSPECTOR_KEY_FILE }}

--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -3,3 +3,5 @@ iproute
 openstack-ironic-inspector
 psmisc
 sqlite
+httpd
+mod_ssl 

--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -1,0 +1,42 @@
+#!/usr/bin/bash
+
+APACHE_CONFIG=/etc/httpd/conf.d/ironic-inspector.conf
+
+export IRONIC_INSPECTOR_CERT_FILE=/certs/ironic-inspector/tls.crt
+export IRONIC_INSPECTOR_KEY_FILE=/certs/ironic-inspector/tls.key
+export INSPECTOR_REVERSE_PROXY_SETUP=${INSPECTOR_REVERSE_PROXY_SETUP:-"false"}
+
+if [ -f "$IRONIC_INSPECTOR_CERT_FILE" ] && [ ! -f "$IRONIC_INSPECTOR_KEY_FILE" ] ; then
+    echo "Missing TLS Certificate key file /certs/ironic-inspector/tls.key"
+    exit 1
+fi
+if [ ! -f "$IRONIC_INSPECTOR_CERT_FILE" ] && [ -f "$IRONIC_INSPECTOR_KEY_FILE" ] ; then
+    echo "Missing TLS Certificate file /certs/ironic-inspector/tls.crt"
+    exit 1
+fi
+
+if [ -f "$IRONIC_INSPECTOR_CERT_FILE" ]; then
+    export IRONIC_INSPECTOR_TLS_SETUP="true"
+else
+    export IRONIC_INSPECTOR_TLS_SETUP="false"
+    export INSPECTOR_REVERSE_PROXY_SETUP="false" # If TLS is not used, we have no reason to use the reverse proxy
+    exit 0
+fi
+
+function build_j2_config() {
+  CONFIG_FILE=$1
+python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < $CONFIG_FILE.j2
+}
+
+# Configure HTTP basic auth for API server
+HTPASSWD_FILE=/etc/ironic-inspector/htpasswd
+if [ -n "${HTTP_BASIC_HTPASSWD}" ]; then
+    printf "%s\n" "${HTTP_BASIC_HTPASSWD}" >"${HTPASSWD_FILE}"
+fi
+
+build_j2_config $APACHE_CONFIG > $APACHE_CONFIG
+sed -i "/Listen 80/c\#Listen 80" /etc/httpd/conf/httpd.conf
+sed -i 's/User apache/User ironic-inspector/g' /etc/httpd/conf/httpd.conf
+sed -i 's/Group apache/Group ironic-inspector/g' /etc/httpd/conf/httpd.conf
+exec /usr/sbin/httpd -DFOREGROUND
+

--- a/scripts/runironic-inspector
+++ b/scripts/runironic-inspector
@@ -11,6 +11,7 @@ export IRONIC_INSECURE=${IRONIC_INSECURE:-false}
 export IRONIC_INSPECTOR_CACERT_FILE=/certs/ca/ironic-inspector/tls.crt
 export IRONIC_INSPECTOR_CERT_FILE=/certs/ironic-inspector/tls.crt
 export IRONIC_INSPECTOR_KEY_FILE=/certs/ironic-inspector/tls.key
+export INSPECTOR_REVERSE_PROXY_SETUP=${INSPECTOR_REVERSE_PROXY_SETUP:-"false"}
 
 if [ -f "$IRONIC_INSPECTOR_CERT_FILE" ] && [ ! -f "$IRONIC_INSPECTOR_KEY_FILE" ] ; then
     echo "Missing TLS Certificate key file /certs/ironic-inspector/tls.key"
@@ -34,6 +35,7 @@ if [ -f "$IRONIC_INSPECTOR_CERT_FILE" ]; then
 else
     export IRONIC_INSPECTOR_TLS_SETUP="false"
     export IRONIC_INSPECTOR_BASE_URL="http://${IRONIC_URL_HOST}:5050"
+    export INSPECTOR_REVERSE_PROXY_SETUP="false" # If TLS is not used, we have no reason to use the reverse proxy
 fi
 
 if [ -f "$IRONIC_CERT_FILE" ] || [ -f "$IRONIC_CACERT_FILE" ]; then
@@ -47,26 +49,30 @@ else
     export IRONIC_BASE_URL="http://${IRONIC_URL_HOST}:6385"
 fi
 
-
 cp $CONFIG $CONFIG.orig
 
 function build_j2_config() {
-python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < $CONFIG.j2
+  CONFIG_FILE=$1
+python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < $CONFIG_FILE.j2
 }
 
 # Merge with the original configuration file from the package.
-build_j2_config | crudini --merge /etc/ironic-inspector/ironic-inspector.conf
+build_j2_config $CONFIG | crudini --merge /etc/ironic-inspector/ironic-inspector.conf
+
 
 # Configure HTTP basic auth for API server
 HTPASSWD_FILE=/etc/ironic-inspector/htpasswd
 if [ -n "${HTTP_BASIC_HTPASSWD}" ]; then
     printf "%s\n" "${HTTP_BASIC_HTPASSWD}" >"${HTPASSWD_FILE}"
-    crudini --set $CONFIG DEFAULT auth_strategy http_basic
-    crudini --set $CONFIG DEFAULT http_basic_auth_user_file "${HTPASSWD_FILE}"
+    if [[ $INSPECTOR_REVERSE_PROXY_SETUP == "false" ]]
+    then
+      crudini --set $CONFIG DEFAULT auth_strategy http_basic
+      crudini --set $CONFIG DEFAULT http_basic_auth_user_file "${HTPASSWD_FILE}"
+    fi
 fi
 
 # Configure auth for ironic client
-CONFIG_OPTIONS="--config-file /etc/ironic-inspector/inspector-dist.conf --config-file ${CONFIG}"
+CONFIG_OPTIONS="--config-file ${CONFIG}"
 auth_config_file="/auth/ironic/auth-config"
 if [ -f ${auth_config_file} ]; then
     CONFIG_OPTIONS+=" --config-file ${auth_config_file}"


### PR DESCRIPTION
This PR provides an option to run Ironic-inspector behind reverse proxy (Apache) and lets this Apache server takes care of TLS. 
* Why we need it: We face an issue when Ironic inspector handles TLS itself using Python SSL library: https://bugzilla.redhat.com/show_bug.cgi?id=1891715 . For this reason, it is better to use Apache server to handle TLS.

Related PRs:
https://github.com/metal3-io/baremetal-operator/pull/728
https://github.com/metal3-io/metal3-dev-env/pull/562