### PR TITLE
Introduce separate ARG for extra packages list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM docker.io/centos:centos8
 
-ARG PKGS_LIST=main-packages-list.txt
+ENV PKGS_LIST=main-packages-list.txt
+ARG EXTRA_PKGS_LIST
+ARG PATCH_LIST
 
-COPY ${PKGS_LIST} ${PATCH_LIST} /tmp/
+COPY ${PKGS_LIST} ${EXTRA_PKGS_LIST:-$PKGS_LIST} ${PATCH_LIST:-$PKGS_LIST} /tmp/
 COPY prepare-image.sh patch-image.sh /bin/
 
 RUN prepare-image.sh && \

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -1,17 +1,22 @@
  #!/usr/bin/bash
 
-set -ex
+set -euxo pipefail
  
 dnf install -y python3 python3-requests
 curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python3 - -b master current-tripleo
 dnf upgrade -y
-xargs -rtd'\n' dnf --setopt=install_weak_deps=False install -y < /tmp/main-packages-list.txt
+xargs -rtd'\n' dnf --setopt=install_weak_deps=False install -y < /tmp/${PKGS_LIST}
+if [[ ! -z ${EXTRA_PKGS_LIST:-} ]]; then
+    if [[ -s /tmp/${EXTRA_PKGS_LIST} ]]; then
+        xargs -rtd'\n' dnf --setopt=install_weak_deps=False install -y < /tmp/${EXTRA_PKGS_LIST}
+    fi
+fi
 mkdir -p /var/lib/ironic-inspector
 sqlite3 /var/lib/ironic-inspector/ironic-inspector.db "pragma journal_mode=wal"
 dnf remove -y sqlite
 dnf clean all
 rm -rf /var/cache/{yum,dnf}/*
-if [[ ! -z ${PATCH_LIST} ]]; then
+if [[ ! -z ${PATCH_LIST:-} ]]; then
     if [[ -s "/tmp/${PATCH_LIST}" ]]; then
         /bin/patch-image.sh;
     fi


### PR DESCRIPTION
Convert the current PKGS_LIST to ENV as we should not really touch it.
Introduce the EXTRA_PKGS_LIST ARG to allow specifying a file
containing a list of extra packages to install.
The goal is to allow installing packages from different sources
to test them.