### PR TITLE
Add options to disable TLS validations

### DIFF
--- a/inspector.conf.j2
+++ b/inspector.conf.j2
@@ -22,6 +22,7 @@ auth_type = none
 endpoint_override = {{ env.IRONIC_BASE_URL }}
 {% if env.IRONIC_TLS_SETUP == "true" %}
 cafile = {{ env.IRONIC_CACERT_FILE }}
+insecure = {{ env.IRONIC_INSECURE }}
 {% endif %}
 
 [processing]

--- a/runironic-inspector.sh
+++ b/runironic-inspector.sh
@@ -6,6 +6,8 @@ export IRONIC_INSPECTOR_ENABLE_DISCOVERY=${IRONIC_INSPECTOR_ENABLE_DISCOVERY:-fa
 
 export IRONIC_CERT_FILE=/certs/ironic/tls.crt
 export IRONIC_CACERT_FILE=/certs/ca/ironic/tls.crt
+export IRONIC_INSECURE=${IRONIC_INSECURE:-false}
+
 export IRONIC_INSPECTOR_CACERT_FILE=/certs/ca/ironic-inspector/tls.crt
 export IRONIC_INSPECTOR_CERT_FILE=/certs/ironic-inspector/tls.crt
 export IRONIC_INSPECTOR_KEY_FILE=/certs/ironic-inspector/tls.key


### PR DESCRIPTION
We excluded these options from the initial proposal because they
reduce security. But since the provisioning IP may not be easily
predicted, it may be hard to generate suitable certificates, so
the insecure option is added to fascilitate two-step migration
from fully insecure HTTP to fully secure HTTPS.