### PR TITLE
Remove chmod command in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,5 @@ COPY ironic-inspector.conf.j2 /etc/ironic-inspector/
 COPY scripts/ /bin/
 
 HEALTHCHECK CMD /bin/runhealthcheck
-RUN chmod +x /bin/runironic-inspector
 
 ENTRYPOINT ["/bin/runironic-inspector"]


### PR DESCRIPTION
The script is already executable, when it's copied to the container should maintain the original execute bit.