### PR TITLE
Prevent bugged behavior of COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN prepare-image.sh && \
   rm -f /bin/prepare-image.sh
 
 COPY ironic-inspector.conf.j2 /etc/ironic-inspector/
-COPY scripts/ /bin/
+COPY scripts/* /bin/
 
 HEALTHCHECK CMD /bin/runhealthcheck
 


### PR DESCRIPTION
When using COPY feature of copying entire content of a dir, it's
better to be explicit and use * .