### PR TITLE
 Provide a way to apply upstream patches to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM docker.io/centos:centos8
 
 ARG PKGS_LIST=main-packages-list.txt
 
-COPY ${PKGS_LIST} /tmp/main-packages-list.txt
-COPY prepare-image.sh /bin/
+COPY ${PKGS_LIST} ${PATCH_LIST} /tmp/
+COPY prepare-image.sh patch-image.sh /bin/
 
 RUN prepare-image.sh && \
   rm -f /bin/prepare-image.sh

--- a/README.md
+++ b/README.md
@@ -3,3 +3,17 @@
 This repo contains the files needed to build the Ironic Inspector images used by Metal3.
 
 When updated, builds are automatically triggered on https://quay.io/repository/metal3-io/ironic-inspector/
+
+Applying Patches to the image
+-----------------------------
+
+When building the image, it is possible to specify a patch of one or more
+upstream projects to apply to the image, passing a file with the patch list
+using the PATCH_LIST build argument.
+
+At the moment, only projects hosted in opendev.org are supported.
+
+Each line of the file is in the form "project_dir refspec" where:
+- project is the last part of the project url including the org, for example openstack/ironic-inspector
+- refspec is the gerrit refspec of the patch we want to test, for example refs/changes/96/766996/2
+

--- a/patch-image.sh
+++ b/patch-image.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/bash
+set -ex
+
+patch_file="/tmp/${PATCH_LIST}"
+
+while IFS= read -r line
+do
+    # each line is in the form "project_dir refsspec" where:
+    # - project is the last part of the project url including the org,
+    # for example openstack/ironic-inspector
+    # - refspec is the gerrit refspec of the patch we want to test,
+    # for example refs/changes/96/766996/2
+    PROJECT=$(echo $line | cut -d " " -f1)
+    PROJ_NAME=$(echo $PROJECT | cut -d "/" -f2)
+    PROJ_URL="https://opendev.org/$PROJECT"
+    REFSPEC=$(echo $line | cut -d " " -f2)
+
+    cd /tmp
+    git clone "$PROJ_URL"
+    cd "$PROJ_NAME"
+    git fetch "$PROJ_URL" "$REFSPEC"
+    git checkout FETCH_HEAD
+
+    SKIP_GENERATE_AUTHORS=1 SKIP_WRITE_GIT_CHANGELOG=1 python3 setup.py sdist
+    pip3 install dist/*.tar.gz
+done < "$patch_file"
+
+cd /

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -11,3 +11,9 @@ sqlite3 /var/lib/ironic-inspector/ironic-inspector.db "pragma journal_mode=wal"
 dnf remove -y sqlite
 dnf clean all
 rm -rf /var/cache/{yum,dnf}/*
+if [[ ! -z ${PATCH_LIST} ]]; then
+    if [[ -s "/tmp/${PATCH_LIST}" ]]; then
+        /bin/patch-image.sh;
+    fi
+fi
+rm -f /bin/patch-image.sh


### PR DESCRIPTION
This change allows users to apply patches to the images during build
time directly from gerrit using the new arg PATCH.
At the moment, it's limited to a single project per image; future
patches will allow applying patches from multiple projects, and
also from local directories.