### PR TITLE
Remove entrypoint instruction from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,4 @@ COPY scripts/ /bin/
 COPY ./inspector-apache.conf.j2 /etc/httpd/conf.d/ironic-inspector.conf.j2
 HEALTHCHECK CMD /bin/runhealthcheck
 RUN rm /etc/httpd/conf.d/ssl.conf -f
-RUN chmod +x /bin/runironic-inspector 
 
-ENTRYPOINT ["/bin/runironic-inspector"]


### PR DESCRIPTION
It should not be needed anymore.